### PR TITLE
fix: restore WakaTime Code Time README action

### DIFF
--- a/.github/workflows/waka.yml
+++ b/.github/workflows/waka.yml
@@ -15,27 +15,42 @@ permissions:
 
 jobs:
   update-readme:
-    name: WakaReadme DevMetrics
+    name: Update README Code Time
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.WAKA_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || secrets.WAKA_GH_TOKEN || github.token }}
 
-      - name: Validate required secrets
+      - name: Check WakaTime secret
+        id: wakatime-secret
         shell: bash
         run: |
           if [ -z "${{ secrets.WAKATIME_API_KEY }}" ]; then
-            echo "::error::Missing secret WAKATIME_API_KEY"
-            exit 1
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=WakaTime skipped::Missing repository secret WAKATIME_API_KEY. Add it in Settings > Secrets and variables > Actions, then run this workflow again."
+            {
+              echo "### Waka Readme skipped"
+              echo ""
+              echo "Missing repository secret \`WAKATIME_API_KEY\`."
+              echo "Add it in **Settings > Secrets and variables > Actions**, then run this workflow manually."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
-      - name: Update README with WakaTime stats
-        uses: anmol098/waka-readme-stats@v4
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Update README with WakaTime Code Time
+        if: steps.wakatime-secret.outputs.should_run == 'true'
+        uses: anmol098/waka-readme-stats@master
         with:
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
-          GH_TOKEN: ${{ secrets.WAKA_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.WAKA_GH_TOKEN || github.token }}
+          SECTION_NAME: waka
+          SHOW_TOTAL_CODE_TIME: "True"
+          SHOW_UPDATED_DATE: "True"
+          UPDATED_DATE_FORMAT: "%Y-%m-%d %H:%M:%S %Z"
           SHOW_COMMIT: "False"
           SHOW_DAYS_OF_WEEK: "False"
           SHOW_LANGUAGE: "False"
@@ -44,7 +59,7 @@ jobs:
           SHOW_EDITORS: "False"
           SHOW_TIMEZONE: "False"
           SHOW_LANGUAGE_PER_REPO: "False"
+          SHOW_PROFILE_VIEWS: "False"
           SHOW_SHORT_INFO: "False"
           SHOW_LINES_OF_CODE: "False"
           SHOW_LOC_CHART: "False"
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Code Time
 
 <!--START_SECTION:waka-->
-
+> Code Time will appear here after the Waka Readme workflow runs with `WAKATIME_API_KEY` configured.
 <!--END_SECTION:waka-->
 
 ## GitHub stats


### PR DESCRIPTION
## Summary
- Make the WakaTime README workflow skip gracefully when `WAKATIME_API_KEY` is missing instead of failing the run.
- Switch the WakaTime stats action to the current `master` action entrypoint so `SHOW_TOTAL_CODE_TIME` is available.
- Explicitly enable Code Time and keep the README section minimal.
- Add a small fallback message inside the README WakaTime section until the workflow successfully updates it.

## Notes
To show real Code Time, add `WAKATIME_API_KEY` in repository Actions secrets and run the **Waka Readme** workflow manually once.